### PR TITLE
GetMemoryUsage returns a value in kilo-bytes not in bytes on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ if (ServerMonitoring == nil) then require("server_monitoring") end
 
 local CPUUsage            = ServerMonitoring:GetCPUUsage()    -- 0-100
 local TotalPhysicalMemory = ServerMonitoring:GetTotalMemory() -- bytes
-local PhysicalMemoryUsage = ServerMonitoring:GetMemoryUsage() -- bytes
+local PhysicalMemoryUsage = ServerMonitoring:GetMemoryUsage() -- bytes (Windows), kilo-bytes (Linux)
 
 print(CPUUsage, TotalPhysicalMemory, PhysicalMemoryUsage)
 ```


### PR DESCRIPTION
The `GetMemoryUsage` function seems returns a value in kilo-bytes and when I search in the [stack overflow](https://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process/64166#64166) page, the author says "**Note: this value is in KB!**" in Linux section.

I can confirm this error by comparing the data from my CentOS server which returned by the module and what the `top` command tells me.